### PR TITLE
DATA-240 Add sandpit node permissions to actions

### DIFF
--- a/standard_policy.json
+++ b/standard_policy.json
@@ -7,7 +7,8 @@
             "Principal": {
                 "AWS": [
                     "arn:aws:iam::593291632749:role/airflow-dev-node-instance-role",
-                    "arn:aws:iam::593291632749:role/airflow-prod-node-instance-role"
+                    "arn:aws:iam::593291632749:role/airflow-prod-node-instance-role",
+                    "arn:aws:iam::593291632749:role/airflow-sandpit-node-instance-role"
                 ]
             },
             "Action": [


### PR DESCRIPTION
This PR adds the Sandpit node group to the permissions list of the standard build-and-push process. This will not take effect retroactively, but means all new and updated images going forwards will by default be accessable from the Sandpit for troubleshooting, saving the need to manually copy them over. Obviously this will not resolve any permissions issues (a similar solution for duplicating required IAM roles is in the backlog), but will help initially.