### PR TITLE
🛂 Add Analytical Platform Compute accounts to repository policy

### DIFF
--- a/standard_policy.json
+++ b/standard_policy.json
@@ -8,7 +8,10 @@
                 "AWS": [
                     "arn:aws:iam::593291632749:role/airflow-dev-node-instance-role",
                     "arn:aws:iam::593291632749:role/airflow-prod-node-instance-role",
-                    "arn:aws:iam::593291632749:role/airflow-sandpit-node-instance-role"
+                    "arn:aws:iam::593291632749:role/airflow-sandpit-node-instance-role",
+                    "arn:aws:iam::381491960855:root",
+                    "arn:aws:iam::767397661611:root",
+                    "arn:aws:iam::992382429243:root"
                 ]
             },
             "Action": [


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/4490
- Adds all of Analytical Platform Compute's root account principal
  - We cannot specify a node role like Airflow EKS because the role names are dynamically generated per EKS managed node group

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 